### PR TITLE
[기능 수정] 예산 월별 목록 조회 / 예산 다중 생성 / 예산 수정 입력 데이터 포맷 변경

### DIFF
--- a/budget/serializers.py
+++ b/budget/serializers.py
@@ -33,10 +33,6 @@ class BudgetListSerializer(serializers.ModelSerializer):
         ]
 
 
-class BudgetCreateSerializer(serializers.Serializer):
-    start_date = serializers.DateField()
-    end_date = serializers.DateField()
-    budget_data = serializers.DictField()
 
 
 class BudgetDetailSerializer(serializers.ModelSerializer):
@@ -55,8 +51,14 @@ class BudgetDetailSerializer(serializers.ModelSerializer):
         ]
 
 
+class BudgetCreateSerializer(serializers.Serializer):
+    start_date = serializers.DateField()
+    end_date = serializers.DateField()
+    budget_data = serializers.DictField()
+
+
 class BudgetUpdateSerializer(serializers.Serializer):
-    category = serializers.CharField()
+    category = serializers.IntegerField()
     money = serializers.IntegerField()
     start_date = serializers.DateField()
     end_date = serializers.DateField()

--- a/budget/serializers.py
+++ b/budget/serializers.py
@@ -34,10 +34,9 @@ class BudgetListSerializer(serializers.ModelSerializer):
 
 
 class BudgetCreateSerializer(serializers.Serializer):
-    category = serializers.CharField()
-    money = serializers.IntegerField()
     start_date = serializers.DateField()
     end_date = serializers.DateField()
+    budget_data = serializers.DictField()
 
 
 class BudgetDetailSerializer(serializers.ModelSerializer):

--- a/budget/views.py
+++ b/budget/views.py
@@ -3,6 +3,7 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework import status
 from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
 
 from budget.models import Budget
 from budget.serializers import BudgetCreateSerializer, BudgetDetailSerializer, BudgetListSerializer, BudgetSerializer, BudgetUpdateSerializer
@@ -13,14 +14,29 @@ from categories.models import Category
 class BudgetAPIView(APIView):
     permission_classes = [IsAuthenticated]
 
-
+    query_month = openapi.Parameter(
+        "month", openapi.IN_QUERY, type=openapi.TYPE_NUMBER, description="검색 월"
+    )
+    @swagger_auto_schema(
+        request_body=None,
+        manual_parameters=[
+            query_month
+        ],
+        responses={
+            status.HTTP_200_OK : BudgetListSerializer
+        }
+    )
     def get(self, request):
         """
         예산 목록
         """
         user = request.user
+        month = request.query_params.get('month', None)
 
-        budget_list = Budget.objects.filter(user=user)
+        if month is None:
+            budget_list = Budget.objects.filter(user=user)
+        else:
+            budget_list = Budget.objects.filter(user=user, start_date__month=month)
         
         serializer = BudgetListSerializer(budget_list, many=True)
 


### PR DESCRIPTION
## 반영 브랜치
feature/budget/#17 -> develop

## 변경 사항
### 예산 목록 API
- 월별 목록을 확인할 수 있도록 변경
### 예산 생성 API
- 단일 목록만 생성이 가능했다면, 한번에 여러 항목들을 생성할 수 있도록 변경
```json
# 변경 전
{
  "category": "식비",
  "money": 1000000,
  "start_date": "2023-11-01",
  "end_date": "2023-11-30"
}

# 변경 후
{
  "start_date": "2023-11-01",
  "end_date": "2023-11-30",
  "budget_data": {
    "효도비": 50000,
    "적금": 100000,
    "카페": 30000
  }
}
```

### 예산 수정 API
- 카테고리 id를 입력 받을 수 있게 serializer 변경


